### PR TITLE
Fixed params set in uploadDocumentByContents() to match api documentation

### DIFF
--- a/src/Docparser/DocparserApiRequest.php
+++ b/src/Docparser/DocparserApiRequest.php
@@ -113,9 +113,12 @@ class DocparserApiRequest
             $request = [
                 'multipart' => [
                     [
-                        'name' => 'file',
+                        'name' => 'file_content',
                         'contents' => $fileContent,
-                        'filename' => ($filename) ? $filename : null
+                    ],
+                    [
+                        'name' => 'file_name',
+                        'contents' => $filename,
                     ],
                     [
                         'name' => 'remote_id',


### PR DESCRIPTION
According to API docs, field for file contents is _file_content_ , not _file_. Optional _file_name_ was missing as well. 

API docs: https://dev.docparser.com/#import-documents