### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0||^7.0"
     },
     "autoload": {
     	"psr-4": { "Docparser\\": "src/Docparser" }


### PR DESCRIPTION
Latest stable of Guzzle is version 7. By specifying ~6.0 only. a lot of people cannot install your package